### PR TITLE
Fix Poseidon2 arity and visibility

### DIFF
--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -21,8 +21,6 @@ use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 pub use round_numbers::poseidon2_round_numbers_128;
 
-const SUPPORTED_WIDTHS: [usize; 12] = [2, 3, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40];
-
 /// The Poseidon2 permutation.
 #[derive(Clone, Debug)]
 pub struct Poseidon2<F, MdsLight, Diffusion, const WIDTH: usize, const D: u64> {
@@ -60,7 +58,7 @@ where
         internal_constants: Vec<F>,
         internal_linear_layer: Diffusion,
     ) -> Self {
-        assert!(SUPPORTED_WIDTHS.contains(&WIDTH));
+        assert!(WIDTH == 2 || WIDTH == 3 || WIDTH % 4 == 0);
         Self {
             rounds_f,
             external_constants,

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -21,7 +21,7 @@ use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 pub use round_numbers::poseidon2_round_numbers_128;
 
-const SUPPORTED_WIDTHS: [usize; 8] = [2, 3, 4, 8, 12, 16, 20, 24];
+const SUPPORTED_WIDTHS: [usize; 12] = [2, 3, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40];
 
 /// The Poseidon2 permutation.
 #[derive(Clone, Debug)]

--- a/poseidon2/src/matrix.rs
+++ b/poseidon2/src/matrix.rs
@@ -106,7 +106,8 @@ fn mds_light_permutation<AF: AbstractField, MdsPerm4: MdsPermutation<AF, 4>, con
             state[2] += sum;
         }
 
-        4 | 8 | 12 | 16 | 20 | 24 | 28 | 32 | 36 | 40 => {
+        _ => {
+            assert!(WIDTH % 4 == 0, "Unsupported width");
             // First, we apply M_4 to each consecutive four elements of the state.
             // In Appendix B's terminology, this replaces each x_i with x_i'.
             for i in (0..WIDTH).step_by(4) {
@@ -135,10 +136,6 @@ fn mds_light_permutation<AF: AbstractField, MdsPerm4: MdsPermutation<AF, 4>, con
             for i in 0..WIDTH {
                 state[i] += sums[i % 4].clone();
             }
-        }
-
-        _ => {
-            panic!("Unsupported width");
         }
     }
 }

--- a/poseidon2/src/matrix.rs
+++ b/poseidon2/src/matrix.rs
@@ -106,7 +106,7 @@ fn mds_light_permutation<AF: AbstractField, MdsPerm4: MdsPermutation<AF, 4>, con
             state[2] += sum;
         }
 
-        4 | 8 | 12 | 16 | 20 | 24 => {
+        4 | 8 | 12 | 16 | 20 | 24 | 28 | 32 | 36 | 40 => {
             // First, we apply M_4 to each consecutive four elements of the state.
             // In Appendix B's terminology, this replaces each x_i with x_i'.
             for i in (0..WIDTH).step_by(4) {

--- a/poseidon2/src/matrix.rs
+++ b/poseidon2/src/matrix.rs
@@ -39,7 +39,7 @@ where
 // [ 1 1 2 3 ]
 // [ 3 1 1 2 ].
 // This is more efficient than the previous matrix.
-fn apply_mat4<AF>(x: &mut [AF; 4])
+pub fn apply_mat4<AF>(x: &mut [AF; 4])
 where
     AF: AbstractField,
 {

--- a/symmetric/src/lib.rs
+++ b/symmetric/src/lib.rs
@@ -7,7 +7,7 @@ extern crate alloc;
 mod compression;
 mod hash;
 mod hasher;
-mod permutation;
+pub mod permutation;
 mod serializing_hasher;
 mod sponge;
 


### PR DESCRIPTION
This PR changes 3 things:

1) It changes the hard-coded supported widths to allow for any poseidon2 width needed for loam.

2) It changes the visibility of `apply_mat4` to remove some a TODO code duplication change in loam.

3) It changes the visibility of the `poseidon2::permutation` module. This is needed to support pre-generated Poseidon 2 constants.