### PR TITLE
chore: Minimal ports from sp1-new for sphinx compatibility

### DIFF
--- a/commit/src/domain.rs
+++ b/commit/src/domain.rs
@@ -8,6 +8,8 @@ use p3_field::{
 use p3_matrix::dense::RowMajorMatrix;
 use p3_matrix::Matrix;
 use p3_util::{log2_ceil_usize, log2_strict_usize};
+use serde::de::DeserializeOwned;
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug)]
 pub struct LagrangeSelectors<T> {
@@ -53,7 +55,9 @@ pub trait PolynomialSpace: Copy {
     fn selectors_on_coset(&self, coset: Self) -> LagrangeSelectors<Vec<Self::Val>>;
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Serialize, Deserialize)]
+#[serde(bound(serialize = "Val: Serialize"))]
+#[serde(bound(deserialize = "Val: DeserializeOwned"))]
 pub struct TwoAdicMultiplicativeCoset<Val: TwoAdicField> {
     pub log_n: usize,
     pub shift: Val,

--- a/fri/src/two_adic_pcs.rs
+++ b/fri/src/two_adic_pcs.rs
@@ -42,6 +42,10 @@ impl<Val, Dft, InputMmcs, FriMmcs> TwoAdicFriPcs<Val, Dft, InputMmcs, FriMmcs> {
             _phantom: PhantomData,
         }
     }
+
+    pub fn fri_config(&self) -> &FriConfig<FriMmcs> {
+        &self.fri
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone)]

--- a/matrix/src/lib.rs
+++ b/matrix/src/lib.rs
@@ -12,6 +12,7 @@ use core::ops::Deref;
 use itertools::{izip, Itertools};
 use p3_field::{dot_product, AbstractExtensionField, ExtensionField, Field, PackedValue};
 use p3_maybe_rayon::prelude::*;
+use serde::{Deserialize, Serialize};
 use strided::{VerticallyStridedMatrixView, VerticallyStridedRowIndexMap};
 
 use crate::dense::RowMajorMatrix;
@@ -26,7 +27,7 @@ pub mod stack;
 pub mod strided;
 pub mod util;
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Serialize, Deserialize)]
 pub struct Dimensions {
     pub width: usize,
     pub height: usize,

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -17,7 +17,7 @@ use tracing::instrument;
 ///
 /// This generally shouldn't be used directly. If you're using a Merkle tree as an MMCS,
 /// see `FieldMerkleTreeMmcs`.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FieldMerkleTree<F, W, M, const DIGEST_ELEMS: usize> {
     pub(crate) leaves: Vec<M>,
     // Enable serialization for this field whenever the underlying array type supports it (len 1-32).


### PR DESCRIPTION
This PR imports a few changes from `sp1-new` that `sphinx` depends on. 