### PR TITLE
ci: Check downstream compiles

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,4 +7,6 @@
 xclippy = [
     "clippy", "--all-targets", "--",
     "-Wclippy::all",
+    "-Aclippy::multiple_bound_locations",
+    #"-Arenamed_and_removed_lints",
 ]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,10 @@
+[alias]
+# Collection of project wide clippy lints. This is done via an alias because
+# clippy doesn't currently allow for specifiying project-wide lints in a
+# configuration file. This is a similar workaround to the ones presented here:
+# <https://github.com/EmbarkStudios/rust-ecosystem/issues/59>
+# TODO: add support for --all-features
+xclippy = [
+    "clippy", "--all-targets", "--",
+    "-Wclippy::all",
+]

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,12 @@
+[profile.ci]
+# Print out output for failing tests as soon as they fail, and also at the end
+# of the run (for easy scrollability).
+failure-output = "immediate-final"
+# Show skipped tests in the CI output.
+status-level = "skip"
+# Do not cancel the test run on the first failure.
+fail-fast = false
+# Mark tests as slow after 5mins, kill them after 20mins
+slow-timeout = { period = "300s", terminate-after = 4 }
+# Retry failed tests once, marked flaky if test then passes
+retries = 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
   pull_request:
     branches: [ "*" ]
 
@@ -11,118 +11,100 @@ env:
   CARGO_INCREMENTAL: 1
 
 jobs:
-  build_and_test:
-    name: Build and Test
+  test:
+    # Change to warp-ubuntu-latest-x64-16x for a more powerful runner
     runs-on: ubuntu-latest
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
-
     steps:
-    - uses: actions/checkout@v4
+      - name: Set up git private repo access
+        run: |
+          git config --global url."https://${{ secrets.REPO_TOKEN }}@github.com/".insteadOf ssh://git@github.com
+          git config --global url."https://${{ secrets.REPO_TOKEN }}@github.com".insteadOf https://github.com
+      - uses: actions/checkout@v4
+        with:
+          repository: lurk-lab/ci-workflows
+      - uses: ./.github/actions/ci-env
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: taiki-e/install-action@nextest
+      - uses: Swatinem/rust-cache@v2
+      - name: Linux Tests
+        run: |
+          cargo nextest run --profile ci --workspace
+      - name: Linux Tests with the parallel feeature
+        run: |
+          cargo nextest run --profile ci --workspace --features parallel
 
-    - uses: dtolnay/rust-toolchain@stable
-      id: rs-stable
-
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: rust-${{ steps.rs-stable.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.toml') }}
-
-    - name: Build
-      run: cargo build --verbose --all-targets
-
-    - name: Check with parallel
-      run: cargo check --verbose --all-targets --features parallel
-
-    - name: Test
-      run: cargo test --verbose
-
-    - name: Test with parallel
-      run: cargo test --verbose --features parallel
-
-  lint:
-    name: Formatting and Clippy
+  clippy:
     runs-on: ubuntu-latest
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
-
     steps:
-    - uses: actions/checkout@v4
+      - name: Set up git private repo access
+        run: |
+          git config --global url."https://${{ secrets.REPO_TOKEN }}@github.com/".insteadOf ssh://git@github.com
+          git config --global url."https://${{ secrets.REPO_TOKEN }}@github.com".insteadOf https://github.com
+      - uses: actions/checkout@v4
+        with:
+          repository: lurk-lab/ci-workflows
+      - uses: ./.github/actions/ci-env
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check Rustfmt Code Style
+        run: cargo fmt --all --check
+      - name: check *everything* compiles
+        run: cargo check --all-targets --all-features --workspace --examples --tests --benches
+      # See '.cargo/config' for list of enabled/disabled clippy lints
+      - name: Check clippy warnings
+        run: cargo xclippy -D warnings
+      - name: Doctests
+        run: cargo test --doc --workspace
 
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-          components: clippy
-      id: rs-stable
-
-    - uses: dtolnay/rust-toolchain@nightly
-      with:
-        components: rustfmt
-
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: rust-${{ steps.rs-stable.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.toml') }}
-
-    - name: Clippy
-      run: cargo +stable clippy --all-targets -- -D warnings
-
-    - name: Format
-      run: cargo +nightly fmt --all -- --check 
-
-  check_crates:
-    name: Check Crates
-    runs-on: ubuntu-latest
-    if: "! contains(toJSON(github.event.commits.*.message), '[skip-ci]')"
-
+  check-downstream-compiles:
+    runs-on: warp-ubuntu-latest-x64-16x
+    if: ${{ github.base_ref == 'sp1-new' }}
     steps:
-    - uses: actions/checkout@v4
-
-    - uses: dtolnay/rust-toolchain@stable
-      id: rs-stable
-
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: rust-${{ steps.rs-stable.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.toml', '**/Cargo.lock') }}
-  
-    - name: Cargo Check Crates
-      run: |
-        cargo check --verbose --package p3-air
-        cargo check --verbose --package p3-baby-bear
-        cargo check --verbose --package p3-blake3
-        cargo check --verbose --package p3-challenger
-        cargo check --verbose --package p3-commit
-        cargo check --verbose --package p3-dft
-        cargo check --verbose --package p3-field
-        cargo check --verbose --package p3-field-testing
-        cargo check --verbose --package p3-fri
-        cargo check --verbose --package p3-goldilocks
-        cargo check --verbose --package p3-interpolation
-        cargo check --verbose --package p3-keccak
-        cargo check --verbose --package p3-keccak-air
-        cargo check --verbose --package p3-lde
-        cargo check --verbose --package p3-matrix
-        cargo check --verbose --package p3-maybe-rayon
-        cargo check --verbose --package p3-mds
-        cargo check --verbose --package p3-merkle-tree
-        cargo check --verbose --package p3-mersenne-31
-        cargo check --verbose --package p3-monolith
-        cargo check --verbose --package p3-poseidon
-        cargo check --verbose --package p3-poseidon2
-        cargo check --verbose --package p3-rescue
-        cargo check --verbose --package p3-symmetric
-        cargo check --verbose --package p3-uni-stark
-        cargo check --verbose --package p3-util
+      - name: Set up git private repo access
+        run: |
+          git config --global url."https://${{ secrets.REPO_TOKEN }}@github.com/".insteadOf ssh://git@github.com
+          git config --global url."https://${{ secrets.REPO_TOKEN }}@github.com".insteadOf https://github.com
+      - uses: actions/checkout@v4
+        with:
+          repository: lurk-lab/ci-workflows
+          path: ci-workflows
+      - uses: ./ci-workflows/.github/actions/ci-env
+      # Check that lurk-lab/sphinx compiles
+      - name: Set env
+        run: |
+          echo "UPSTREAM_REPO=$(echo "lurk-lab/Plonky3" | awk -F'/' '{ print $2 }')" | tee -a $GITHUB_ENV
+          echo "DOWNSTREAM_REPO=$(echo "lurk-lab/sphinx" | awk -F'/' '{ print $2 }')" | tee -a $GITHUB_ENV
+          echo "DOWNSTREAM_REPO_2=$(echo "lurk-lab/zk-light-clients" | awk -F'/' '{ print $2 }')" | tee -a $GITHUB_ENV
+      - uses: actions/checkout@v4
+        with:
+          path: ${{ github.workspace }}/${{ env.UPSTREAM_REPO }}
+      - uses: actions/checkout@v4
+        with:
+          repository: "lurk-lab/${{ env.DOWNSTREAM_REPO }}"
+          path: ${{ github.workspace }}/${{ env.DOWNSTREAM_REPO }}
+          token: ${{ secrets.REPO_TOKEN }}
+      - uses: actions/checkout@v4
+        with:
+          repository: "lurk-lab/${{ env.DOWNSTREAM_REPO_2 }}"
+          path: ${{ github.workspace }}/${{ env.DOWNSTREAM_REPO_2 }}
+          token: ${{ secrets.REPO_TOKEN }}
+      - name: Setup CI
+        uses: ./sphinx/.github/actions/setup
+        with:
+          pull_token: ${{ secrets.REPO_TOKEN }}
+          perf: false
+      - name: Install deps
+        run: |
+          sudo apt-get update && sudo apt-get install -y build-essential pkg-config libssl-dev libudev-dev cmake
+          cd sphinx/cli
+          cargo install --locked --force --path .
+          cargo prove install-toolchain
+          echo "RUSTFLAGS=${{env.RUSTFLAGS}} --cfg tokio_unstable" | tee -a $GITHUB_ENV
+      - uses: ./ci-workflows/.github/actions/check-downstream-compiles
+        with:
+          upstream-path: "${{ env.UPSTREAM_REPO }}"
+          downstream-path: "${{ env.DOWNSTREAM_REPO }}"
+          more-paths: "${{ env.DOWNSTREAM_REPO_2 }}/aptos"
+          patch-ssh: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,6 @@ jobs:
         with:
           repository: lurk-lab/ci-workflows
           path: ci-workflows
-          ref: downstream-transitive
       - uses: ./ci-workflows/.github/actions/ci-env
       - name: Set env
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,10 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 1
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   test:
     # Change to warp-ubuntu-latest-x64-16x for a more powerful runner
@@ -70,6 +74,7 @@ jobs:
         with:
           repository: lurk-lab/ci-workflows
           path: ci-workflows
+          ref: downstream-transitive
       - uses: ./ci-workflows/.github/actions/ci-env
       # Check that lurk-lab/sphinx compiles
       - name: Set env

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [ "main", "dev" ]
+    branches: [ "main", "dev", "sp1-new" ]
   pull_request:
     branches: [ "*" ]
 
@@ -62,9 +62,11 @@ jobs:
       - name: Doctests
         run: cargo test --doc --workspace
 
+  # On a push or pull request to `sp1-new`, check downstream crates compile, i.e.
+  # lurk-lab/sphinx and lurk-lab/zk-light-clients
   check-downstream-compiles:
     runs-on: warp-ubuntu-latest-x64-16x
-    if: ${{ github.base_ref == 'sp1-new' }}
+    if: ${{ github.base_ref == 'sp1-new' || github.ref_name == 'sp1-new' }}
     steps:
       - name: Set up git private repo access
         run: |
@@ -76,7 +78,6 @@ jobs:
           path: ci-workflows
           ref: downstream-transitive
       - uses: ./ci-workflows/.github/actions/ci-env
-      # Check that lurk-lab/sphinx compiles
       - name: Set env
         run: |
           echo "UPSTREAM_REPO=$(echo "lurk-lab/Plonky3" | awk -F'/' '{ print $2 }')" | tee -a $GITHUB_ENV

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "stable"
+profile = "default"


### PR DESCRIPTION
- Adds a `check-downstream-compiles` test for Sphinx and zk-light-clients based on [an improved reusable workflow](https://github.com/lurk-lab/ci-workflows/compare/downstream-transitive?expand=1)
- Cherry-picks general CI streamlining changes for `sp1-new`

> [!NOTE]
> Merging this PR requires changing the `sp1-new` branch protection rule, as the names of required checks have changed