### PR TITLE
Add poseidon fixes to `sp1-new-tmp` branch

### DIFF
--- a/air/src/air.rs
+++ b/air/src/air.rs
@@ -163,6 +163,12 @@ pub struct FilteredAirBuilder<'a, AB: AirBuilder> {
     condition: AB::Expr,
 }
 
+impl<'a, AB: AirBuilder> FilteredAirBuilder<'a, AB> {
+    pub fn condition(&self) -> AB::Expr {
+        self.condition.clone()
+    }
+}
+
 impl<'a, AB: AirBuilder> AirBuilder for FilteredAirBuilder<'a, AB> {
     type F = AB::F;
     type Expr = AB::Expr;

--- a/bn254-fr/src/poseidon2.rs
+++ b/bn254-fr/src/poseidon2.rs
@@ -19,13 +19,13 @@ fn get_diffusion_matrix_3() -> &'static [Bn254Fr; 3] {
 #[derive(Debug, Clone, Default)]
 pub struct DiffusionMatrixBN254;
 
-impl<AF: AbstractField + From<Bn254Fr>> Permutation<[AF; 3]> for DiffusionMatrixBN254 {
+impl<AF: AbstractField<F = Bn254Fr>> Permutation<[AF; 3]> for DiffusionMatrixBN254 {
     fn permute_mut(&self, state: &mut [AF; 3]) {
         matmul_internal::<Bn254Fr, AF, 3>(state, *get_diffusion_matrix_3());
     }
 }
 
-impl<AF: AbstractField + From<Bn254Fr>> DiffusionPermutation<AF, 3> for DiffusionMatrixBN254 {}
+impl<AF: AbstractField<F = Bn254Fr>> DiffusionPermutation<AF, 3> for DiffusionMatrixBN254 {}
 
 #[cfg(test)]
 mod tests {

--- a/bn254-fr/src/poseidon2.rs
+++ b/bn254-fr/src/poseidon2.rs
@@ -19,13 +19,13 @@ fn get_diffusion_matrix_3() -> &'static [Bn254Fr; 3] {
 #[derive(Debug, Clone, Default)]
 pub struct DiffusionMatrixBN254;
 
-impl<AF: AbstractField<F = Bn254Fr>> Permutation<[AF; 3]> for DiffusionMatrixBN254 {
+impl<AF: AbstractField + From<Bn254Fr>> Permutation<[AF; 3]> for DiffusionMatrixBN254 {
     fn permute_mut(&self, state: &mut [AF; 3]) {
         matmul_internal::<Bn254Fr, AF, 3>(state, *get_diffusion_matrix_3());
     }
 }
 
-impl<AF: AbstractField<F = Bn254Fr>> DiffusionPermutation<AF, 3> for DiffusionMatrixBN254 {}
+impl<AF: AbstractField + From<Bn254Fr>> DiffusionPermutation<AF, 3> for DiffusionMatrixBN254 {}
 
 #[cfg(test)]
 mod tests {

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -94,37 +94,49 @@ const MATRIX_DIAG_20_GOLDILOCKS: [Goldilocks; 20] =
 #[derive(Debug, Clone, Default)]
 pub struct DiffusionMatrixGoldilocks;
 
-impl<AF: AbstractField<F = Goldilocks>> Permutation<[AF; 8]> for DiffusionMatrixGoldilocks {
+impl<AF: AbstractField + From<Goldilocks>> Permutation<[AF; 8]> for DiffusionMatrixGoldilocks {
     fn permute_mut(&self, state: &mut [AF; 8]) {
-        matmul_internal::<Goldilocks, AF, 8>(state, MATRIX_DIAG_8_GOLDILOCKS);
+        matmul_internal(state, MATRIX_DIAG_8_GOLDILOCKS);
     }
 }
 
-impl<AF: AbstractField<F = Goldilocks>> DiffusionPermutation<AF, 8> for DiffusionMatrixGoldilocks {}
+impl<AF: AbstractField + From<Goldilocks>> DiffusionPermutation<AF, 8>
+    for DiffusionMatrixGoldilocks
+{
+}
 
-impl<AF: AbstractField<F = Goldilocks>> Permutation<[AF; 12]> for DiffusionMatrixGoldilocks {
+impl<AF: AbstractField + From<Goldilocks>> Permutation<[AF; 12]> for DiffusionMatrixGoldilocks {
     fn permute_mut(&self, state: &mut [AF; 12]) {
-        matmul_internal::<Goldilocks, AF, 12>(state, MATRIX_DIAG_12_GOLDILOCKS);
+        matmul_internal(state, MATRIX_DIAG_12_GOLDILOCKS);
     }
 }
 
-impl<AF: AbstractField<F = Goldilocks>> DiffusionPermutation<AF, 12> for DiffusionMatrixGoldilocks {}
+impl<AF: AbstractField + From<Goldilocks>> DiffusionPermutation<AF, 12>
+    for DiffusionMatrixGoldilocks
+{
+}
 
-impl<AF: AbstractField<F = Goldilocks>> Permutation<[AF; 16]> for DiffusionMatrixGoldilocks {
+impl<AF: AbstractField + From<Goldilocks>> Permutation<[AF; 16]> for DiffusionMatrixGoldilocks {
     fn permute_mut(&self, state: &mut [AF; 16]) {
-        matmul_internal::<Goldilocks, AF, 16>(state, MATRIX_DIAG_16_GOLDILOCKS);
+        matmul_internal(state, MATRIX_DIAG_16_GOLDILOCKS);
     }
 }
 
-impl<AF: AbstractField<F = Goldilocks>> DiffusionPermutation<AF, 16> for DiffusionMatrixGoldilocks {}
+impl<AF: AbstractField + From<Goldilocks>> DiffusionPermutation<AF, 16>
+    for DiffusionMatrixGoldilocks
+{
+}
 
-impl<AF: AbstractField<F = Goldilocks>> Permutation<[AF; 20]> for DiffusionMatrixGoldilocks {
+impl<AF: AbstractField + From<Goldilocks>> Permutation<[AF; 20]> for DiffusionMatrixGoldilocks {
     fn permute_mut(&self, state: &mut [AF; 20]) {
-        matmul_internal::<Goldilocks, AF, 20>(state, MATRIX_DIAG_20_GOLDILOCKS);
+        matmul_internal(state, MATRIX_DIAG_20_GOLDILOCKS);
     }
 }
 
-impl<AF: AbstractField<F = Goldilocks>> DiffusionPermutation<AF, 20> for DiffusionMatrixGoldilocks {}
+impl<AF: AbstractField + From<Goldilocks>> DiffusionPermutation<AF, 20>
+    for DiffusionMatrixGoldilocks
+{
+}
 
 pub const HL_GOLDILOCKS_8_EXTERNAL_ROUND_CONSTANTS: [[u64; 8]; 8] = [
     [

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -100,10 +100,7 @@ impl<AF: AbstractField<F = Goldilocks>> Permutation<[AF; 8]> for DiffusionMatrix
     }
 }
 
-impl<AF: AbstractField<F = Goldilocks>> DiffusionPermutation<AF, 8>
-    for DiffusionMatrixGoldilocks
-{
-}
+impl<AF: AbstractField<F = Goldilocks>> DiffusionPermutation<AF, 8> for DiffusionMatrixGoldilocks {}
 
 impl<AF: AbstractField<F = Goldilocks>> Permutation<[AF; 12]> for DiffusionMatrixGoldilocks {
     fn permute_mut(&self, state: &mut [AF; 12]) {
@@ -111,10 +108,7 @@ impl<AF: AbstractField<F = Goldilocks>> Permutation<[AF; 12]> for DiffusionMatri
     }
 }
 
-impl<AF: AbstractField<F = Goldilocks>> DiffusionPermutation<AF, 12>
-    for DiffusionMatrixGoldilocks
-{
-}
+impl<AF: AbstractField<F = Goldilocks>> DiffusionPermutation<AF, 12> for DiffusionMatrixGoldilocks {}
 
 impl<AF: AbstractField<F = Goldilocks>> Permutation<[AF; 16]> for DiffusionMatrixGoldilocks {
     fn permute_mut(&self, state: &mut [AF; 16]) {
@@ -122,10 +116,7 @@ impl<AF: AbstractField<F = Goldilocks>> Permutation<[AF; 16]> for DiffusionMatri
     }
 }
 
-impl<AF: AbstractField<F = Goldilocks>> DiffusionPermutation<AF, 16>
-    for DiffusionMatrixGoldilocks
-{
-}
+impl<AF: AbstractField<F = Goldilocks>> DiffusionPermutation<AF, 16> for DiffusionMatrixGoldilocks {}
 
 impl<AF: AbstractField<F = Goldilocks>> Permutation<[AF; 20]> for DiffusionMatrixGoldilocks {
     fn permute_mut(&self, state: &mut [AF; 20]) {
@@ -133,10 +124,7 @@ impl<AF: AbstractField<F = Goldilocks>> Permutation<[AF; 20]> for DiffusionMatri
     }
 }
 
-impl<AF: AbstractField<F = Goldilocks>> DiffusionPermutation<AF, 20>
-    for DiffusionMatrixGoldilocks
-{
-}
+impl<AF: AbstractField<F = Goldilocks>> DiffusionPermutation<AF, 20> for DiffusionMatrixGoldilocks {}
 
 pub const HL_GOLDILOCKS_8_EXTERNAL_ROUND_CONSTANTS: [[u64; 8]; 8] = [
     [

--- a/goldilocks/src/poseidon2.rs
+++ b/goldilocks/src/poseidon2.rs
@@ -94,46 +94,46 @@ const MATRIX_DIAG_20_GOLDILOCKS: [Goldilocks; 20] =
 #[derive(Debug, Clone, Default)]
 pub struct DiffusionMatrixGoldilocks;
 
-impl<AF: AbstractField + From<Goldilocks>> Permutation<[AF; 8]> for DiffusionMatrixGoldilocks {
+impl<AF: AbstractField<F = Goldilocks>> Permutation<[AF; 8]> for DiffusionMatrixGoldilocks {
     fn permute_mut(&self, state: &mut [AF; 8]) {
         matmul_internal(state, MATRIX_DIAG_8_GOLDILOCKS);
     }
 }
 
-impl<AF: AbstractField + From<Goldilocks>> DiffusionPermutation<AF, 8>
+impl<AF: AbstractField<F = Goldilocks>> DiffusionPermutation<AF, 8>
     for DiffusionMatrixGoldilocks
 {
 }
 
-impl<AF: AbstractField + From<Goldilocks>> Permutation<[AF; 12]> for DiffusionMatrixGoldilocks {
+impl<AF: AbstractField<F = Goldilocks>> Permutation<[AF; 12]> for DiffusionMatrixGoldilocks {
     fn permute_mut(&self, state: &mut [AF; 12]) {
         matmul_internal(state, MATRIX_DIAG_12_GOLDILOCKS);
     }
 }
 
-impl<AF: AbstractField + From<Goldilocks>> DiffusionPermutation<AF, 12>
+impl<AF: AbstractField<F = Goldilocks>> DiffusionPermutation<AF, 12>
     for DiffusionMatrixGoldilocks
 {
 }
 
-impl<AF: AbstractField + From<Goldilocks>> Permutation<[AF; 16]> for DiffusionMatrixGoldilocks {
+impl<AF: AbstractField<F = Goldilocks>> Permutation<[AF; 16]> for DiffusionMatrixGoldilocks {
     fn permute_mut(&self, state: &mut [AF; 16]) {
         matmul_internal(state, MATRIX_DIAG_16_GOLDILOCKS);
     }
 }
 
-impl<AF: AbstractField + From<Goldilocks>> DiffusionPermutation<AF, 16>
+impl<AF: AbstractField<F = Goldilocks>> DiffusionPermutation<AF, 16>
     for DiffusionMatrixGoldilocks
 {
 }
 
-impl<AF: AbstractField + From<Goldilocks>> Permutation<[AF; 20]> for DiffusionMatrixGoldilocks {
+impl<AF: AbstractField<F = Goldilocks>> Permutation<[AF; 20]> for DiffusionMatrixGoldilocks {
     fn permute_mut(&self, state: &mut [AF; 20]) {
         matmul_internal(state, MATRIX_DIAG_20_GOLDILOCKS);
     }
 }
 
-impl<AF: AbstractField + From<Goldilocks>> DiffusionPermutation<AF, 20>
+impl<AF: AbstractField<F = Goldilocks>> DiffusionPermutation<AF, 20>
     for DiffusionMatrixGoldilocks
 {
 }

--- a/poseidon2/src/diffusion.rs
+++ b/poseidon2/src/diffusion.rs
@@ -18,13 +18,13 @@ use p3_symmetric::Permutation;
 pub trait DiffusionPermutation<T: Clone, const WIDTH: usize>: Permutation<[T; WIDTH]> {}
 
 /// Given a vector v compute the matrix vector product (1 + diag(v))state with 1 denoting the constant matrix of ones.
-pub fn matmul_internal<F: Field, AF: AbstractField + From<F>, const WIDTH: usize>(
+pub fn matmul_internal<F: Field, AF: AbstractField<F = F>, const WIDTH: usize>(
     state: &mut [AF; WIDTH],
     mat_internal_diag_m_1: [F; WIDTH],
 ) {
     let sum: AF = state.iter().cloned().sum();
     for i in 0..WIDTH {
-        state[i] *= mat_internal_diag_m_1[i].into();
+        state[i] *= AF::from_f(mat_internal_diag_m_1[i]);
         state[i] += sum.clone();
     }
 }

--- a/poseidon2/src/diffusion.rs
+++ b/poseidon2/src/diffusion.rs
@@ -17,13 +17,14 @@ use p3_symmetric::Permutation;
 
 pub trait DiffusionPermutation<T: Clone, const WIDTH: usize>: Permutation<[T; WIDTH]> {}
 
-pub fn matmul_internal<F: Field, AF: AbstractField<F = F>, const WIDTH: usize>(
+/// Given a vector v compute the matrix vector product (1 + diag(v))state with 1 denoting the constant matrix of ones.
+pub fn matmul_internal<F: Field, AF: AbstractField + From<F>, const WIDTH: usize>(
     state: &mut [AF; WIDTH],
     mat_internal_diag_m_1: [F; WIDTH],
 ) {
     let sum: AF = state.iter().cloned().sum();
     for i in 0..WIDTH {
-        state[i] *= AF::from_f(mat_internal_diag_m_1[i]);
+        state[i] *= mat_internal_diag_m_1[i].into();
         state[i] += sum.clone();
     }
 }

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -21,8 +21,6 @@ use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 pub use round_numbers::poseidon2_round_numbers_128;
 
-const SUPPORTED_WIDTHS: [usize; 8] = [2, 3, 4, 8, 12, 16, 20, 24];
-
 /// The Poseidon2 permutation.
 #[derive(Clone, Debug)]
 pub struct Poseidon2<F, MdsLight, Diffusion, const WIDTH: usize, const D: u64> {
@@ -60,7 +58,7 @@ where
         internal_constants: Vec<F>,
         internal_linear_layer: Diffusion,
     ) -> Self {
-        assert!(SUPPORTED_WIDTHS.contains(&WIDTH));
+        assert!(WIDTH == 2 || WIDTH == 3 || (WIDTH > 0 && WIDTH % 4 == 0));
         Self {
             rounds_f,
             external_constants,

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -21,8 +21,9 @@ use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 pub use round_numbers::poseidon2_round_numbers_128;
 
-const fn supported_width(width: usize) -> bool {
-    width == 2 || width == 3 || (width > 0 && width % 4 == 0)
+/// Only support WIDTH parameters of 2, 3, or multiples of 4.
+const fn supported_width<const WIDTH: usize>() -> bool {
+    WIDTH == 2 || WIDTH == 3 || (WIDTH != 0 && WIDTH % 4 == 0)
 }
 
 /// The Poseidon2 permutation.
@@ -62,7 +63,7 @@ where
         internal_constants: Vec<F>,
         internal_linear_layer: Diffusion,
     ) -> Self {
-        assert!(supported_width(WIDTH));
+        assert!(supported_width::<WIDTH>());
         Self {
             rounds_f,
             external_constants,

--- a/poseidon2/src/lib.rs
+++ b/poseidon2/src/lib.rs
@@ -21,6 +21,10 @@ use rand::distributions::{Distribution, Standard};
 use rand::Rng;
 pub use round_numbers::poseidon2_round_numbers_128;
 
+const fn supported_width(width: usize) -> bool {
+    width == 2 || width == 3 || (width > 0 && width % 4 == 0)
+}
+
 /// The Poseidon2 permutation.
 #[derive(Clone, Debug)]
 pub struct Poseidon2<F, MdsLight, Diffusion, const WIDTH: usize, const D: u64> {
@@ -58,7 +62,7 @@ where
         internal_constants: Vec<F>,
         internal_linear_layer: Diffusion,
     ) -> Self {
-        assert!(WIDTH == 2 || WIDTH == 3 || (WIDTH > 0 && WIDTH % 4 == 0));
+        assert!(supported_width(WIDTH));
         Self {
             rounds_f,
             external_constants,

--- a/poseidon2/src/matrix.rs
+++ b/poseidon2/src/matrix.rs
@@ -1,4 +1,3 @@
-use crate::supported_width;
 use p3_field::AbstractField;
 use p3_mds::MdsPermutation;
 use p3_symmetric::Permutation;

--- a/poseidon2/src/matrix.rs
+++ b/poseidon2/src/matrix.rs
@@ -1,7 +1,8 @@
-use crate::supported_width;
 use p3_field::AbstractField;
 use p3_mds::MdsPermutation;
 use p3_symmetric::Permutation;
+
+use crate::supported_width;
 
 extern crate alloc;
 

--- a/poseidon2/src/matrix.rs
+++ b/poseidon2/src/matrix.rs
@@ -1,3 +1,4 @@
+use crate::supported_width;
 use p3_field::AbstractField;
 use p3_mds::MdsPermutation;
 use p3_symmetric::Permutation;

--- a/poseidon2/src/matrix.rs
+++ b/poseidon2/src/matrix.rs
@@ -1,3 +1,4 @@
+use crate::supported_width;
 use p3_field::{AbstractField, PrimeField};
 use p3_mds::MdsPermutation;
 use p3_symmetric::Permutation;
@@ -92,6 +93,7 @@ fn mds_light_permutation<AF: AbstractField, MdsPerm4: MdsPermutation<AF, 4>, con
     state: &mut [AF; WIDTH],
     mdsmat: MdsPerm4,
 ) {
+    assert!(supported_width(WIDTH), "Unsupported width");
     match WIDTH {
         2 => {
             let sum = state[0].clone() + state[1].clone();
@@ -106,7 +108,7 @@ fn mds_light_permutation<AF: AbstractField, MdsPerm4: MdsPermutation<AF, 4>, con
             state[2] += sum;
         }
 
-        4 | 8 | 12 | 16 | 20 | 24 => {
+        _ => {
             // First, we apply M_4 to each consecutive four elements of the state.
             // In Appendix B's terminology, this replaces each x_i with x_i'.
             for i in (0..WIDTH).step_by(4) {
@@ -135,10 +137,6 @@ fn mds_light_permutation<AF: AbstractField, MdsPerm4: MdsPermutation<AF, 4>, con
             for i in 0..WIDTH {
                 state[i] += sums[i % 4].clone();
             }
-        }
-
-        _ => {
-            panic!("Unsupported width");
         }
     }
 }

--- a/poseidon2/src/matrix.rs
+++ b/poseidon2/src/matrix.rs
@@ -1,5 +1,5 @@
 use crate::supported_width;
-use p3_field::{AbstractField, PrimeField};
+use p3_field::AbstractField;
 use p3_mds::MdsPermutation;
 use p3_symmetric::Permutation;
 
@@ -147,17 +147,14 @@ pub struct Poseidon2ExternalMatrixGeneral;
 impl<AF, const WIDTH: usize> Permutation<[AF; WIDTH]> for Poseidon2ExternalMatrixGeneral
 where
     AF: AbstractField,
-    AF::F: PrimeField,
 {
     fn permute_mut(&self, state: &mut [AF; WIDTH]) {
         mds_light_permutation::<AF, MDSMat4, WIDTH>(state, MDSMat4)
     }
 }
 
-impl<AF, const WIDTH: usize> MdsLightPermutation<AF, WIDTH> for Poseidon2ExternalMatrixGeneral
-where
-    AF: AbstractField,
-    AF::F: PrimeField,
+impl<AF, const WIDTH: usize> MdsLightPermutation<AF, WIDTH> for Poseidon2ExternalMatrixGeneral where
+    AF: AbstractField
 {
 }
 
@@ -167,16 +164,13 @@ pub struct Poseidon2ExternalMatrixHL;
 impl<AF, const WIDTH: usize> Permutation<[AF; WIDTH]> for Poseidon2ExternalMatrixHL
 where
     AF: AbstractField,
-    AF::F: PrimeField,
 {
     fn permute_mut(&self, state: &mut [AF; WIDTH]) {
         mds_light_permutation::<AF, HLMDSMat4, WIDTH>(state, HLMDSMat4)
     }
 }
 
-impl<AF, const WIDTH: usize> MdsLightPermutation<AF, WIDTH> for Poseidon2ExternalMatrixHL
-where
-    AF: AbstractField,
-    AF::F: PrimeField,
+impl<AF, const WIDTH: usize> MdsLightPermutation<AF, WIDTH> for Poseidon2ExternalMatrixHL where
+    AF: AbstractField
 {
 }

--- a/poseidon2/src/matrix.rs
+++ b/poseidon2/src/matrix.rs
@@ -93,7 +93,7 @@ fn mds_light_permutation<AF: AbstractField, MdsPerm4: MdsPermutation<AF, 4>, con
     state: &mut [AF; WIDTH],
     mdsmat: MdsPerm4,
 ) {
-    assert!(supported_width(WIDTH), "Unsupported width");
+    assert!(supported_width::<WIDTH>(), "Unsupported width");
     match WIDTH {
         2 => {
             let sum = state[0].clone() + state[1].clone();

--- a/uni-stark/src/prover.rs
+++ b/uni-stark/src/prover.rs
@@ -19,6 +19,7 @@ use crate::{
     StarkGenericConfig, Val,
 };
 
+#[allow(clippy::multiple_bound_locations)]
 #[instrument(skip_all)]
 pub fn prove<
     SC,


### PR DESCRIPTION
This PR moves the commits from `ah/poseidon-arbitrary-width` to the top of the `sp1-new-tmp` branch.